### PR TITLE
CI: fix golangci-lint OOM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ down: $(MIGRATE_BINARY)
 	$(MIGRATE_BINARY) -dir db/migrations postgres "$(DATABASE_URL)" down
 
 $(GOLANGCI_LINT_BINARY): | $(BIN_DIR)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b bin v1.50.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b bin v1.52.0
 
 $(MIGRATE_BINARY): | $(BIN_DIR)
 	go build -mod=vendor -o $@ github.com/pressly/goose/cmd/goose


### PR DESCRIPTION
golangci-lint <= 1.50 does not support Go > 1.20 and will OOM. This PR
fixes the issue.

xref: https://github.com/golangci/golangci-lint/pull/3414

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
