### PR TITLE
api: log 5xx errors

### DIFF
--- a/api/v1alpha1/server.go
+++ b/api/v1alpha1/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/go-jet/jet/v2/qrm"
@@ -23,6 +24,9 @@ func httpError(logger log.Logger) func(w http.ResponseWriter, m string, code int
 		response := Error{
 			Code:  code,
 			Error: m,
+		}
+		if code/100 == 5 {
+			level.Error(logger).Log("msg", "unexpected error", "code", strconv.Itoa(code), "err", m)
 		}
 		hj(w, response, code)
 	}

--- a/store/sql.go
+++ b/store/sql.go
@@ -421,14 +421,11 @@ func (vss *versionsSQLStore) GetOrCreate(ctx context.Context, name string) (*mod
 		return v, nil
 	}
 	if !errors.Is(err, qrm.ErrNoRows) {
-		println("WAS NOT A NO RESULTS ERROR")
 		return nil, err
 	}
 
-	println("WAS A NO RESULTS ERROR")
 	m, err := NewModelsSQLStore(tx, vss.organization).Get(ctx, vss.model)
 	if err != nil {
-		println("DID NOT FIND A MODEL")
 		return nil, err
 	}
 
@@ -438,7 +435,6 @@ func (vss *versionsSQLStore) GetOrCreate(ctx context.Context, name string) (*mod
 
 	v, err = NewVersionsSQLStore(tx, vss.organization, vss.model).Create(ctx, &model.Version{Name: name, Model: m.ID, Organization: m.Organization, Schema: *m.DefaultSchema})
 	if err != nil {
-		println("COULD NOT CREAT E THE VERSION")
 		return nil, err
 	}
 


### PR DESCRIPTION
We currently have no way of investigating unexpected errors encountered
by the server. This commit adds logging for all 5xx errors returned by
the server and cleans up some dirty logs from the store package.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
